### PR TITLE
feat: add `Tint.RGB.complementary_color/1`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ An Elixir library allowing calculations with colors and conversions between
 different colorspaces.
 
 Currently supports the following color models:
+
 * [RGB](https://en.wikipedia.org/wiki/RGB_color_space)
 * [CMYK](https://en.wikipedia.org/wiki/CMYK_color_model)
 * [HSV](https://en.wikipedia.org/wiki/HSL_and_HSV)
@@ -27,7 +28,7 @@ The package can be installed by adding `tint` to your list of dependencies in
 ```elixir
 def deps do
   [
-    {:tint, "~> 1.0"}
+    {:tint, "~> 1.1"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -228,6 +228,13 @@ iex> Tint.Lab.nearest_color(~K[#FF0000], [~K[#009900], ~K[#CC0000]])
 #Tint.RGB<204,0,0 (#CC0000)>
 ```
 
+### Complementary Color
+
+```elixir
+iex> Tint.RGB.complementary_color(~K[#FF0000])
+#Tint.RGB<0,255,255 (#00FFFF)>
+```
+
 ## Docs
 
 The API docs can be found at [HexDocs](https://hexdocs.pm/tint).

--- a/lib/tint/rgb.ex
+++ b/lib/tint/rgb.ex
@@ -181,6 +181,11 @@ defmodule Tint.RGB do
 
   @doc """
   Calculates the complementary of the given RGB color.
+
+  ## Example
+
+      iex> Tint.RGB.complementary_color(%Tint.RGB{red: 255, green: 0, blue: 0})
+      #Tint.RGB<0,255,255 (#00FFFF)>
   """
   @doc since: "1.1.0"
   @spec complementary_color(t) :: t

--- a/lib/tint/rgb.ex
+++ b/lib/tint/rgb.ex
@@ -177,6 +177,21 @@ defmodule Tint.RGB do
     {color.red, color.green, color.blue}
   end
 
+  # Complementary Color
+
+  @doc """
+  Calculates the complementary of the given RGB color.
+  """
+  @doc since: "1.1.0"
+  @spec complementary_color(t) :: t
+  def complementary_color(%__MODULE__{} = color) do
+    channel_size = @channel_interval.max
+    red = channel_size - color.red
+    green = channel_size - color.green
+    blue = channel_size - color.blue
+    new(red, green, blue)
+  end
+
   # Distance
 
   @doc """

--- a/test/tint/rgb_test.exs
+++ b/test/tint/rgb_test.exs
@@ -355,6 +355,18 @@ defmodule Tint.RGBTest do
     end
   end
 
+  describe "complementary_color/1" do
+    test "get complementary color in RGB colorspace" do
+      assert RGB.complementary_color(~K[#FF0000]) == ~K[#00FFFF]
+      assert RGB.complementary_color(~K[#00FF00]) == ~K[#FF00FF]
+      assert RGB.complementary_color(~K[#0000FF]) == ~K[#FFFF00]
+      assert RGB.complementary_color(~K[#FF8800]) == ~K[#0077FF]
+      assert RGB.complementary_color(~K[#3378F9]) == ~K[#CC8706]
+      assert RGB.complementary_color(~K[#8800FF]) == ~K[#77FF00]
+      assert RGB.complementary_color(~K[#99AA77]) == ~K[#665588]
+    end
+  end
+
   describe "to_hex/1" do
     test "convert RGB color struct to hex code" do
       assert RGB.to_hex(RGB.new(0, 0, 0)) == "#000000"


### PR DESCRIPTION
Allows calculation of the complementary color for the RGB colorspace:

```elixir
assert Tint.RGB.complementary_color(~K[#FF0000]) == ~K[#00FFFF]
assert Tint.RGB.complementary_color(~K[#00FF00]) == ~K[#FF00FF]
assert Tint.RGB.complementary_color(~K[#0000FF]) == ~K[#FFFF00]
```