### PR TITLE
feat: Added Conversions from Lab and XYZ to RGB

### DIFF
--- a/lib/tint/rgb/conversions/from_lab.ex
+++ b/lib/tint/rgb/conversions/from_lab.ex
@@ -1,0 +1,7 @@
+defimpl Tint.RGB.Convertible, for: Tint.Lab do
+  def convert(color) do
+    color
+    |> Tint.to_xyz()
+    |> Tint.to_rgb()
+  end
+end

--- a/lib/tint/rgb/conversions/from_xyz.ex
+++ b/lib/tint/rgb/conversions/from_xyz.ex
@@ -1,0 +1,37 @@
+defimpl Tint.RGB.Convertible, for: Tint.XYZ do
+  alias Tint.RGB
+  alias Tint.XYZ
+
+  def convert(color) do
+    %XYZ{x: x, y: y, z: z} = color
+    x = x / 100
+    y = y / 100
+    z = z / 100
+
+    r = x * 3.240812398895283 - y * 1.5373084456298136 - z * 0.4985865229069666
+
+    g =
+      x * -0.9692430170086407 + y * 1.8759663029085742 + z * 0.04155503085668564
+
+    b =
+      x * 0.055638398436112804 - y * 0.20400746093241362 +
+        z * 1.0571295702861434
+
+    %RGB{
+      red: gamma_compression(r),
+      green: gamma_compression(g),
+      blue: gamma_compression(b)
+    }
+  end
+
+  defp gamma_compression(linear) do
+    v =
+      if linear <= 0.00313066844250060782371 do
+        3294.6 * linear
+      else
+        269.025 * :math.pow(linear, 5.0 / 12.0) - 14.025
+      end
+
+    v |> round() |> min(255) |> max(0)
+  end
+end

--- a/lib/tint/xyz/conversions/from_lab.ex
+++ b/lib/tint/xyz/conversions/from_lab.ex
@@ -1,0 +1,36 @@
+defimpl Tint.XYZ.Convertible, for: Tint.Lab do
+  alias Tint.Lab
+  alias Tint.XYZ
+
+  @cbrt_epsilon 6.0 / 29.0
+  @kappa 24_389.0 / 27.0
+
+  def convert(color) do
+    {l, a, b} = Lab.to_tuple(color)
+
+    fy = (l + 16.0) / 116.0
+    fx = a / 500 + fy
+    fz = fy - b / 200.0
+
+    x = inverse(fx) * 0.9504492182750991
+
+    y =
+      if l > 8 do
+        :math.pow(fy, 3)
+      else
+        l / @kappa
+      end
+
+    z = inverse(fz) * 1.0889166484304715
+
+    %XYZ{x: x * 100, y: y * 100, z: z * 100}
+  end
+
+  defp inverse(coord) do
+    if coord > @cbrt_epsilon do
+      :math.pow(coord, 3)
+    else
+      (coord * 116.0 - 16.0) / @kappa
+    end
+  end
+end

--- a/test/tint_test.exs
+++ b/test/tint_test.exs
@@ -7,6 +7,8 @@ defmodule TintTest do
 
   @rgb_color RGB.new(0, 50, 100)
   @hsv_color HSV.new(210, 1, 0.392)
+  @lab_color Lab.new(50, 10, 10)
+  @xyz_color XYZ.new(0.0179, 0.0017, -0.0526)
 
   describe "converter_for/1" do
     test "CMYK" do
@@ -91,6 +93,41 @@ defmodule TintTest do
 
       assert Tint.convert(@hsv_color, :rgb) == {:ok, rgb_color}
       assert Tint.convert(@hsv_color, RGB) == {:ok, rgb_color}
+    end
+
+    test "XYZ to RGB" do
+      rgb_color = RGB.Convertible.convert(@xyz_color)
+
+      assert Tint.convert(@xyz_color, :rgb) == {:ok, rgb_color}
+      assert Tint.convert(@xyz_color, RGB) == {:ok, rgb_color}
+    end
+
+    test "Lab to XYZ" do
+      xyz_color = XYZ.Convertible.convert(@lab_color)
+
+      assert Tint.convert(@lab_color, :xyz) == {:ok, xyz_color}
+      assert Tint.convert(@lab_color, XYZ) == {:ok, xyz_color}
+    end
+
+    test "Lab to RGB" do
+      rgb_color = RGB.Convertible.convert(@lab_color)
+
+      assert Tint.convert(@lab_color, :rgb) == {:ok, rgb_color}
+      assert Tint.convert(@lab_color, RGB) == {:ok, rgb_color}
+    end
+
+    test "RGB to Lab to RGB round trip" do
+      assert @rgb_color ==
+               @rgb_color
+               |> Tint.to_lab()
+               |> Tint.to_rgb()
+    end
+
+    test "XYZ to Lab to XYZ round trip" do
+      assert @rgb_color ==
+               @rgb_color
+               |> Tint.to_xyz()
+               |> Tint.to_rgb()
     end
 
     test "error on unknown colorspace" do


### PR DESCRIPTION
Hello,

I needed to convert Lab colors to Hex (so RGB) so I found a working implementation here : https://mina86.com/2021/srgb-lab-lchab-conversions/

But for some reason I have to multiply by 100 the results to get actual XYZ colors from Lab, and so divide by 100 to use the given algorithm to get RBG from XYZ. I left a command on that blog post to try to figure out why.

But it works!



